### PR TITLE
drivers: add basic infra for device drivers

### DIFF
--- a/src/bsp/drivers/mod.rs
+++ b/src/bsp/drivers/mod.rs
@@ -1,0 +1,86 @@
+#![allow(dead_code)]
+
+#[derive(Copy, Clone, PartialEq)]
+pub enum InitPhase {
+    Hardware,
+    Protocol,
+}
+
+pub trait DriverDescriptor {
+    fn init(&self) -> Result<(), &'static str>;
+}
+
+#[derive(Copy, Clone)]
+pub struct DeviceDriver {
+    pub description: &'static str,
+    pub descriptor: &'static (dyn DriverDescriptor),
+    pub phase: InitPhase,
+}
+
+// TODO: make number of drivers a compile time thing instead of a hardcoded
+// value, preventing we forgotting to set it correctly.
+// For now, we plan to have 2 drivers only:
+// 1. GPIO
+// 2. UART
+const NUM_DRIVERS: usize = 2;
+
+pub struct DriversManager {
+    drivers: [Option<DeviceDriver>; NUM_DRIVERS],
+    num_registered: usize,
+}
+
+impl DriversManager {
+    fn new() -> Self {
+        Self {
+            drivers: [None; NUM_DRIVERS],
+            num_registered: 0,
+        }
+    }
+
+    pub fn register_driver(&mut self, driver: DeviceDriver) {
+        assert!(self.num_registered <= NUM_DRIVERS);
+        self.drivers[self.num_registered] = Some(driver);
+        self.num_registered += 1;
+    }
+
+    // This method initializes all drivers the manager has registered
+    // within, thus instead of returning a boolean for each (or even a final
+    // boolean for all) we panic!
+    // At the same time, we allow initializing one init phase at a time.
+    pub fn init_drivers(&mut self, init_phase: Option<InitPhase>) {
+        if init_phase.is_none() {
+            for driver in self.drivers {
+                // Just return in case there isn't any driver to be loaded
+                if let Some(drv) = driver {
+                    match drv.descriptor.init() {
+                        Ok(_) => (), // we still lack print macros
+                        Err(_) => panic!("failed to initialize {}", drv.description),
+                    }
+                }
+            }
+            return;
+        }
+
+        // Count the number of drivers in each initialization phase so we
+        // avoid traversing the drivers list for those phases with no driver
+        // at all.
+        let mut phase_count = [0; core::intrinsics::variant_count::<InitPhase>()];
+        for driver in &self.drivers {
+            if let Some(drv) = driver {
+                phase_count[drv.phase as usize] += 1;
+            }
+        }
+
+        for (curr_phase, num_drivers) in phase_count.into_iter().enumerate() {
+            if num_drivers > 0 {
+                self.drivers
+                    .iter_mut()
+                    .filter(|drv| curr_phase == drv.unwrap().phase as usize)
+                    .for_each(|drv| match drv.unwrap().descriptor.init() {
+                        Ok(_) => (), // we still lack print macros
+                        Err(_) => panic!("failed to initialize {}", drv.unwrap().description),
+                    });
+            }
+        }
+    }
+}

--- a/src/bsp/drivers/mod.rs
+++ b/src/bsp/drivers/mod.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+use crate::klib::sync::SingleThreadData;
+
 #[derive(Copy, Clone, PartialEq)]
 pub enum InitPhase {
     Hardware,
@@ -29,12 +31,19 @@ pub struct DriversManager {
     num_registered: usize,
 }
 
+static DRIVERS_MANAGER_ONCE: SingleThreadData<DriversManager> =
+    SingleThreadData::new(DriversManager::new());
+
 impl DriversManager {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             drivers: [None; NUM_DRIVERS],
             num_registered: 0,
         }
+    }
+
+    pub fn instance() -> &'static Self {
+        &DRIVERS_MANAGER_ONCE
     }
 
     pub fn register_driver(&mut self, driver: DeviceDriver) {

--- a/src/bsp/mod.rs
+++ b/src/bsp/mod.rs
@@ -1,0 +1,1 @@
+pub mod drivers;

--- a/src/klib/mod.rs
+++ b/src/klib/mod.rs
@@ -1,0 +1,1 @@
+pub mod sync;

--- a/src/klib/sync.rs
+++ b/src/klib/sync.rs
@@ -1,0 +1,46 @@
+// Some structures in the kernel are going to be accessed or used only in
+// single thread/core scenarios, some will even be used with CPU interrupts
+// disabled. One good example is the device driver manager, which has a
+// single instance (static) during the entire kernel lifetime and is accessed
+// at the start of the kernel to initialize builtin modules.
+//
+// Such static structures are forced to be thread-safe by the Rust compiler,
+// which looks for the implementation of both Send and Sync traits to check
+// its safety, however considering the scenario we mentioned earlier, no
+// multiple threads/cores, we we're fine to make them "thread-safe".
+
+use core::ops::{Deref, DerefMut};
+
+pub struct SingleThreadData<T>
+where
+    T: ?Sized
+{
+    data: T,
+}
+
+impl<T> SingleThreadData<T> {
+    pub const fn new(inner: T) -> Self {
+        Self {
+            data: inner,
+        }
+    }
+}
+
+// Make SingleThreadData thread-safe to the compiler
+unsafe impl<T> Send for SingleThreadData<T> {}
+unsafe impl<T> Sync for SingleThreadData<T> {}
+
+// Get the inner data when deferring SingleThreadData
+impl<T> Deref for SingleThreadData<T>{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+       &self.data
+    }
+}
+
+impl<T> DerefMut for SingleThreadData<T>{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,9 @@
 #![no_main]
 #![no_std]
+#![feature(core_intrinsics)]
+#![feature(variant_count)]
+
+mod bsp;
 
 use core::arch::global_asm;
 use core::panic::PanicInfo;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@
 #![feature(variant_count)]
 
 mod bsp;
+mod klib;
 
-use core::arch::global_asm;
-use core::panic::PanicInfo;
+use core::{arch::global_asm, panic::PanicInfo};
 
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {


### PR DESCRIPTION
This commit adds a simple infrastructure to manage the drivers we plan to have in Lapwing in the first stages of development. The idea is to keep track of each driver by allowing each of them to register themselves within a single manager. There should be only one drivers manager in the kernel running at any given time, which should be declared in the static lifetime, being the reason the reference to the drivers also be &'static.

Some locking mechanism is required or some way to let Rust compiler know the manager will only be created and managed in single thread/core mode with interrupts disabled.