### PR TITLE
Enable GPIO subsystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,7 @@ version = "0.1.0"
 dependencies = [
  "cargo-binutils",
  "rustfilt",
+ "tock-registers",
 ]
 
 [[package]]
@@ -427,6 +428,12 @@ dependencies = [
  "term_size",
  "unicode-width",
 ]
+
+[[package]]
+name = "tock-registers"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
 
 [[package]]
 name = "toml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ panic = "abort"
 [dev-dependencies]
 cargo-binutils = "0.3.6"
 rustfilt = "0.2.1"
+
+[dependencies]
+tock-registers = "0.9.0"

--- a/src/bsp/drivers/gpio.rs
+++ b/src/bsp/drivers/gpio.rs
@@ -1,0 +1,160 @@
+#![allow(dead_code)]
+
+// Read and Write operations are abstracted by tock_registers, with that we
+// don't need to create additional abstraction for generic read() and
+// write() into ::mmio or other crate.
+use tock_registers::{
+    bitmask,
+    fields::FieldValue,
+    interfaces::ReadWriteable,
+    registers::{ReadOnly, ReadWrite, WriteOnly},
+};
+
+use crate::{
+    bsp::mmio,
+    klib::{device, sync},
+};
+
+pub enum PinFnSpec {
+    Input,
+    Output,
+    Alt5,
+    Alt4,
+    Alt0,
+    Alt1,
+    Alt2,
+    Alt3,
+}
+
+pub enum PinPullSpec {
+    None,
+    Up,
+    Down,
+}
+
+#[repr(C)]
+struct Registers {
+    fsel0: ReadWrite<u32>,
+    fsel1: ReadWrite<u32>,
+    fsel2: ReadWrite<u32>,
+    fsel3: ReadWrite<u32>,
+    fsel4: ReadWrite<u32>,
+    fsel5: ReadWrite<u32>,
+    _reserved0: u32,
+    set0: WriteOnly<u32>,
+    set1: WriteOnly<u32>,
+    _reserved1: u32,
+    clr0: ReadOnly<u32>,
+    clr1: ReadOnly<u32>,
+    _reserved2: u32,
+    lev0: ReadOnly<u32>,
+    lev1: ReadOnly<u32>,
+    _reserved3: u32,
+    eds0: ReadWrite<u32>, // write 0b1 to a bit clears it
+    eds1: ReadWrite<u32>, // write 0b1 to a bit clears it
+    _reserved4: u32,
+    ren0: ReadWrite<u32>,
+    ren1: ReadWrite<u32>,
+    _reserved5: u32,
+    fen0: ReadWrite<u32>,
+    fen1: ReadWrite<u32>,
+    _reserved6: u32,
+    hen0: ReadWrite<u32>,
+    hen1: ReadWrite<u32>,
+    _reserved7: u32,
+    len0: ReadWrite<u32>,
+    len1: ReadWrite<u32>,
+    _reserved8: u32,
+    aren0: ReadWrite<u32>,
+    aren1: ReadWrite<u32>,
+    _reserved9: u32,
+    afen0: ReadWrite<u32>,
+    afen1: ReadWrite<u32>,
+    _reserved10: [u32; 16],
+    pull_cntrl0: ReadWrite<u32>,
+    pull_cntrl1: ReadWrite<u32>,
+    pull_cntrl2: ReadWrite<u32>,
+    pull_cntrl3: ReadWrite<u32>,
+}
+
+// In GPIO we're working only with u32 repr regs and to facilitate modifying
+// reg values (that we didn't map with register_bitfields!() macro) we
+// directly create the field value.
+type GPIOFieldValue = FieldValue<u32, ()>;
+
+struct GPIO {
+    registers: mmio::MemMap<Registers>,
+}
+
+impl device::DriverDescriptor for GPIO {
+    fn init(&self) -> Result<(), &'static str> {
+        Ok(())
+    }
+}
+
+// GPIO registers are known to hold values for every available pin, so it's
+// important to always modify values without touch others. At the same time,
+// since every bit might be mapped to a different pin we're going to set
+// values using raw shift arithmetic instead of mapping every possible field
+// with register_bitfields macro.
+//
+// With that, when we're handling regs that each bit maps to a pin the
+// arithmetic is straightforward:
+//
+//  value << <pin number>
+//
+// But when a register uses multiple bits for a single pin (eg. pin function
+// selector (PSEL) and pin pull up/down controller (PUD_PDN_CNTRL)) we end
+// up with multiple sequencial registers for setting the values, requiring
+// us to first define in which register we want modify the value and later
+// the offset we must set to touch the right bits. For that, we can use the
+// following arithmetic:
+//
+//  value << ((<pin number> % <number of pins on reg>) * <number of bits>)
+//
+// For easing our job we can make use of the tock_registers function
+// FieldValue::new with the bitmask macro. And for easing users life we
+// export two functions to work with these registers.
+static GPIO_DRIVER: sync::SafeStaticData<GPIO> = sync::SafeStaticData::new(GPIO::new());
+
+impl GPIO {
+    pub const fn new() -> Self {
+        Self {
+            registers: mmio::MemMap::new(0x7e20_0000),
+        }
+    }
+
+    pub fn set_function(&self, pin: usize, alt: PinFnSpec) {
+        let fsel = match pin {
+            0..=9 => &self.registers.fsel0,
+            10..=19 => &self.registers.fsel1,
+            20..=29 => &self.registers.fsel2,
+            30..=39 => &self.registers.fsel3,
+            40..=49 => &self.registers.fsel4,
+            50..=57 => &self.registers.fsel5,
+            _ => panic!("out of GPIO pin range"),
+        };
+        let value = GPIOFieldValue::new(bitmask!(3), (pin % 10) * 3, alt as u32);
+        fsel.modify(value);
+    }
+
+    pub fn set_pull(&self, pin: usize, pull: PinPullSpec) {
+        let pull_cntrl = match pin {
+            0..=15 => &self.registers.pull_cntrl0,
+            16..=31 => &self.registers.pull_cntrl1,
+            32..=47 => &self.registers.pull_cntrl2,
+            48..=57 => &self.registers.pull_cntrl3,
+            _ => panic!("out of GPIO pin range"),
+        };
+        let value = GPIOFieldValue::new(bitmask!(2), (pin % 16) * 2, pull as u32);
+        pull_cntrl.modify(value)
+    }
+}
+
+pub fn build() -> device::DeviceDriver {
+    device::DeviceDriver {
+        description: "BCM2711 GPIO",
+        descriptor: GPIO_DRIVER.inner(),
+        phase: device::InitPhase::Hardware,
+    }
+}

--- a/src/bsp/drivers/mod.rs
+++ b/src/bsp/drivers/mod.rs
@@ -1,0 +1,8 @@
+mod gpio;
+
+use crate::klib::device;
+
+pub fn devices_build() {
+    let manager = device::DriversManager::instance();
+    manager.register_driver(gpio::build())
+}

--- a/src/bsp/mmio.rs
+++ b/src/bsp/mmio.rs
@@ -1,0 +1,58 @@
+#![allow(dead_code)]
+
+use core::{marker::PhantomData, ops::Deref};
+
+// BCM2711 has three memory mapped access mode
+#[allow(dead_code)]
+pub enum PeripheralMode {
+    Legacy, // 32-bits seen by the peripherics
+    Low,    // VPU "low peripheral" mode enabled
+    Full,   // 35-bit addresses, seen by "large addresses peripherics" (eg. DMA4)
+}
+
+pub struct MemMap<T> {
+    base_addr: usize,
+    phantom: PhantomData<T>,
+}
+
+impl<T> Deref for MemMap<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*(self.base_addr as *const T) }
+    }
+}
+
+impl<T> MemMap<T> {
+    pub const fn new(base_addr: usize) -> Self {
+        Self {
+            base_addr: Self::addr_translate(PeripheralMode::Low, base_addr),
+            phantom: PhantomData,
+        }
+    }
+
+    // When acessing the peripherics it's always important to make sure the
+    // correct memory is being accessed.
+    const fn addr_translate(mode: PeripheralMode, addr: usize) -> usize {
+        // TODO: Get in what state we working on (VPU low peripheral mode?)
+        let curr_mode = PeripheralMode::Legacy;
+
+        match mode {
+            PeripheralMode::Legacy => match curr_mode {
+                PeripheralMode::Low => addr - 0x8000_0000,
+                PeripheralMode::Legacy => addr,
+                PeripheralMode::Full => addr + 0x4_0000_0000,
+            },
+            PeripheralMode::Low => match curr_mode {
+                PeripheralMode::Low => addr,
+                PeripheralMode::Legacy => addr + 0x8000_0000,
+                PeripheralMode::Full => addr + 0x3_8000_0000,
+            },
+            PeripheralMode::Full => match curr_mode {
+                PeripheralMode::Low => addr - 0x3_8000_0000,
+                PeripheralMode::Legacy => addr - 0x4_0000_0000,
+                PeripheralMode::Full => addr,
+            },
+        }
+    }
+}

--- a/src/bsp/mod.rs
+++ b/src/bsp/mod.rs
@@ -1,0 +1,1 @@
+pub mod mmio;

--- a/src/bsp/mod.rs
+++ b/src/bsp/mod.rs
@@ -1,1 +1,2 @@
+pub mod drivers;
 pub mod mmio;

--- a/src/klib/device.rs
+++ b/src/klib/device.rs
@@ -42,8 +42,8 @@ impl DriversManager {
         }
     }
 
-    pub fn instance() -> &'static Self {
-        &DRIVERS_MANAGER_ONCE
+    pub fn instance() -> &'static mut Self {
+        DRIVERS_MANAGER_ONCE.inner()
     }
 
     pub fn register_driver(&mut self, driver: DeviceDriver) {
@@ -56,9 +56,9 @@ impl DriversManager {
     // within, thus instead of returning a boolean for each (or even a final
     // boolean for all) we panic!
     // At the same time, we allow initializing one init phase at a time.
-    pub fn init_drivers(&mut self, init_phase: Option<InitPhase>) {
+    pub fn init_drivers(&self, init_phase: Option<InitPhase>) {
         if init_phase.is_none() {
-            for driver in self.drivers {
+            for driver in &self.drivers {
                 // Just return in case there isn't any driver to be loaded
                 if let Some(drv) = driver {
                     match drv.descriptor.init() {
@@ -83,7 +83,7 @@ impl DriversManager {
         for (curr_phase, num_drivers) in phase_count.into_iter().enumerate() {
             if num_drivers > 0 {
                 self.drivers
-                    .iter_mut()
+                    .iter()
                     .filter(|drv| curr_phase == drv.unwrap().phase as usize)
                     .for_each(|drv| match drv.unwrap().descriptor.init() {
                         Ok(_) => (), // we still lack print macros

--- a/src/klib/device.rs
+++ b/src/klib/device.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use crate::klib::sync::SingleThreadData;
+use crate::klib::sync;
 
 #[derive(Copy, Clone, PartialEq)]
 pub enum InitPhase {
@@ -31,8 +31,8 @@ pub struct DriversManager {
     num_registered: usize,
 }
 
-static DRIVERS_MANAGER_ONCE: SingleThreadData<DriversManager> =
-    SingleThreadData::new(DriversManager::new());
+static DRIVERS_MANAGER_ONCE: sync::SafeStaticData<DriversManager> =
+    sync::SafeStaticData::new(DriversManager::new());
 
 impl DriversManager {
     const fn new() -> Self {

--- a/src/klib/sync.rs
+++ b/src/klib/sync.rs
@@ -11,14 +11,14 @@
 
 use core::cell::UnsafeCell;
 
-pub struct SingleThreadData<T>
+pub struct SafeStaticData<T>
 where
     T: ?Sized,
 {
     pub data: UnsafeCell<T>,
 }
 
-impl<T> SingleThreadData<T> {
+impl<T> SafeStaticData<T> {
     pub const fn new(inner: T) -> Self {
         Self {
             data: UnsafeCell::new(inner),
@@ -30,6 +30,6 @@ impl<T> SingleThreadData<T> {
     }
 }
 
-// Make SingleThreadData thread-safe to the compiler
-unsafe impl<T> Send for SingleThreadData<T> {}
-unsafe impl<T> Sync for SingleThreadData<T> {}
+// Make SafeStaticData thread-safe to the compiler
+unsafe impl<T> Send for SafeStaticData<T> {}
+unsafe impl<T> Sync for SafeStaticData<T> {}

--- a/src/klib/sync.rs
+++ b/src/klib/sync.rs
@@ -9,36 +9,27 @@
 // its safety, however considering the scenario we mentioned earlier, no
 // multiple threads/cores, we we're fine to make them "thread-safe".
 
-use core::ops::{Deref, DerefMut};
+use core::cell::UnsafeCell;
 
 pub struct SingleThreadData<T>
 where
     T: ?Sized,
 {
-    data: T,
+    pub data: UnsafeCell<T>,
 }
 
 impl<T> SingleThreadData<T> {
     pub const fn new(inner: T) -> Self {
-        Self { data: inner }
+        Self {
+            data: UnsafeCell::new(inner),
+        }
+    }
+
+    pub fn inner(&self) -> &mut T {
+        unsafe { &mut *self.data.get() }
     }
 }
 
 // Make SingleThreadData thread-safe to the compiler
 unsafe impl<T> Send for SingleThreadData<T> {}
 unsafe impl<T> Sync for SingleThreadData<T> {}
-
-// Get the inner data when deferring SingleThreadData
-impl<T> Deref for SingleThreadData<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.data
-    }
-}
-
-impl<T> DerefMut for SingleThreadData<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.data
-    }
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 #![feature(core_intrinsics)]
 #![feature(variant_count)]
 
+mod bsp;
 mod klib;
 
 use core::{arch::global_asm, panic::PanicInfo};
@@ -17,5 +18,10 @@ global_asm!(include_str!("arch/boot.s"));
 
 #[no_mangle]
 pub fn _start_kernel() -> ! {
+    bsp::drivers::devices_build();
+
+    let drv_manager = klib::device::DriversManager::instance();
+    drv_manager.init_drivers(None);
+
     loop {}
 }


### PR DESCRIPTION
This PR bring new code for supporting the GPIO peripheral from BCM2711 alongside any additional abstraction to help during development, like the abstraction for MMIO access using `tock_registers` and also modifications in the device infrastructure.